### PR TITLE
Feature/tests for views

### DIFF
--- a/builder/templates/security/login.html
+++ b/builder/templates/security/login.html
@@ -24,7 +24,7 @@
           </div>
 
           <div class="form-group text-center">
-            <a href="#">Suporte</a>
+            <a href="#">Esqueci minha senha</a>
           </div>
 
         </form>

--- a/builder/views/__init__.py
+++ b/builder/views/__init__.py
@@ -21,6 +21,5 @@ def login_permission(group):
                         return function(*args, **kwargs)
             except RoleNotFound:
                 return redirect(url_for('security.not_authorized'))
-            return redirect(url_for('security.not_authorized'))
         return wrapper
     return decorator

--- a/builder/views/security.py
+++ b/builder/views/security.py
@@ -22,7 +22,7 @@ def login():
             if user.validate_password(password):
                 login_user(user)
                 user.reload_stats()
-                return redirect(url_for('security.home'))
+                return redirect(url_for('security.dashboard'))
             else:
                 raise PasswordMismatch
 

--- a/builder/views/security.py
+++ b/builder/views/security.py
@@ -40,15 +40,10 @@ def login():
     return render_template('security/login.html', form=form, form_action=url_for('security.login'))
 
 
-@blueprint.route('/support', methods=['GET', 'POST'])
-def suppport():
-    """Return page of support"""
-    return render_template('security/support.html')
-
-
 @blueprint.route('/logout', methods=['GET'])
 def logout():
     """Logout current user"""
+    flash('Usuário deslogado!', category='info')
     logout_user()
     return redirect(url_for('security.login'))
 
@@ -88,8 +83,5 @@ def change_password():
 
         except PasswordMismatch:
             flash('Os campos senha e confirmação não estão iguais!', category='danger')
-
-        except:
-            flash('Não foi possível alterar a senha, tente mais tarde!', category='info')
 
     return render_template('security/change-password.html', form=form)

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ mock==2.0.0
 pytest_cov==2.3.1
 mixer==5.5.7
 blinker==1.4
+Flask-WebTest==0.0.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,13 +126,26 @@ def su_login(login, superuser):
 
 @pytest.fixture()
 def superuser(superuser_role):
-    from builder.models import User, UserRole
+    from builder.models import User
     user = User()
     user.username = 'Darth_Vader'
     user.email = 'mayforce@bewith.you'
     user.name = 'Anakin Skywalker'
     user.password = user.generate_password(password='12345678')
     user.set_role(superuser_role)
+    user.save(commit=True)
+    return user
+
+
+@pytest.fixture()
+def admin(admin_role):
+    from builder.models import User
+    user = User()
+    user.username = 'Luke'
+    user.email = 'mayforce@bewith.me'
+    user.name = 'Luke Skywalker'
+    user.password = user.generate_password(password='12345678')
+    user.set_role(admin_role)
     user.save(commit=True)
     return user
 
@@ -154,6 +167,7 @@ def superuser_role():
     from builder.models import Role
     role = Role()
     role.name = 'superuser'
+    role.description = 'Super Usuário'
     role.save(commit=True)
     return role
 
@@ -173,5 +187,6 @@ def client_role():
     from builder.models import Role
     role = Role()
     role.name = 'client'
+    role.description = 'Cliente'
     role.save(commit=True)
     return role

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ import os
 os.environ['BUILDER_ENV'] = 'test'
 
 import pytest
+from flask import url_for
 from flask.testing import FlaskClient
+from webtest import TestApp
 from builder.main import db
 
 
@@ -93,6 +95,33 @@ def all(request, app, db_session):
         request.cls.app = app
     # This fix is to use the `all()` built-in function normally
     return __builtins__['all']
+
+
+@pytest.yield_fixture()
+def client(app):
+    with app.test_client() as _client:
+        yield _client
+
+
+@pytest.fixture()
+def webtest(app):
+    return TestApp(app)
+
+
+@pytest.fixture()
+def login(webtest):
+    def helper(username, password):
+        login_view = webtest.get(url_for('security.login')).maybe_follow()
+        form = login_view.form
+        form['username'] = username
+        form['password'] = password
+        return form.submit().maybe_follow()
+    return helper
+
+
+@pytest.fixture()
+def su_login(login, superuser):
+    return login(username='Darth_Vader', password='12345678')
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ os.environ['BUILDER_ENV'] = 'test'
 import pytest
 from flask import url_for
 from flask.testing import FlaskClient
-from webtest import TestApp
+from flask_webtest import TestApp
 from builder.main import db
 
 

--- a/tests/views/test_core.py
+++ b/tests/views/test_core.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+import pytest
+from flask import url_for
+
+@pytest.mark.parametrize('view, kwargs, template', [
+    ('core.list_projects', {},  'core/index.html'),
+])
+def test_templates(view, kwargs, template, su_login, webtest):
+    response = webtest.get(url_for(view, **kwargs)).maybe_follow()
+    assert response.template == template

--- a/tests/views/test_security.py
+++ b/tests/views/test_security.py
@@ -55,3 +55,9 @@ def test_change_password_without_success(old_password, password, confirm, messag
     form['confirm'] = confirm
     response = form.submit().maybe_follow()
     assert message == response.flashes[0][1]
+
+
+def test_cached_session_send_to_dashboard(user_login, webtest):
+    response = webtest.get(url_for('security.login')).maybe_follow()
+    assert response.request.path == '/dashboard'
+    assert response.template == 'security/dashboard.html'

--- a/tests/views/test_security.py
+++ b/tests/views/test_security.py
@@ -54,4 +54,4 @@ def test_change_password_without_success(old_password, password, confirm, messag
     form['password'] = password
     form['confirm'] = confirm
     response = form.submit().maybe_follow()
-    assert message in response.body.decode()
+    assert message == response.flashes[0][1]

--- a/tests/views/test_security.py
+++ b/tests/views/test_security.py
@@ -1,0 +1,57 @@
+# coding: utf8
+import pytest
+from flask import url_for
+
+
+@pytest.fixture()
+def user_login(login, user):
+    return login(username='Chewbaca', password='12345678')
+
+
+def test_login_user_with_success(user_login):
+    assert '<h3>Bem vindo Chewbaca da Silva!</h3>' in user_login.body.decode()
+
+
+def test_login_user_without_success(login, user):
+    response = login(username='Chewbaca', password='123456')
+    assert 'Usuário ou senha inválido' in response.body.decode()
+
+
+def test_logout(user_login, webtest):
+    assert '<h3>Bem vindo Chewbaca da Silva!</h3>' in user_login.body.decode()
+    response = webtest.get(url_for('security.logout')).maybe_follow()
+    assert 'Usuário deslogado' in response.body.decode()
+    response = webtest.get(url_for('security.dashboard')).maybe_follow()
+    assert 'Faça o login antes de continuar' in response.body.decode()
+
+
+def test_normal_user_in_access_restric_access(user_login, webtest):
+    response = webtest.get(url_for('users.list_roles')).maybe_follow()
+    assert '<h2>Você não tem permissão para acessar essa página</h2>' in response.body.decode()
+
+
+def test_change_password_proccess_with_success(user_login, login, webtest):
+    response = webtest.get(url_for('security.change_password')).maybe_follow()
+    form = response.form
+    form['old_password'] = '12345678'
+    form['password'] = 'sw1234'
+    form['confirm'] = 'sw1234'
+    form.submit().maybe_follow()
+    webtest.get(url_for('security.logout')).maybe_follow()
+    response = login(username='Chewbaca', password='sw1234')
+    assert '<h3>Bem vindo Chewbaca da Silva!</h3>' in response.body.decode()
+
+
+@pytest.mark.parametrize('old_password, password, confirm, message',[
+    ('1234567', 'sw1234', 'sw1234', 'Senha do usuário inválida!'),
+    ('12345678', 'sw123', 'sw123', 'A senha tem de ter no mínimo 6 caracteres!'),
+    ('12345678', 'sw1234', 'sw12345', 'Os campos senha e confirmação não estão iguais!')
+])
+def test_change_password_without_success(old_password, password, confirm, message, user_login, webtest):
+    response = webtest.get(url_for('security.change_password')).maybe_follow()
+    form = response.form
+    form['old_password'] = old_password
+    form['password'] = password
+    form['confirm'] = confirm
+    response = form.submit().maybe_follow()
+    assert message in response.body.decode()

--- a/tests/views/test_users.py
+++ b/tests/views/test_users.py
@@ -2,6 +2,13 @@
 import pytest
 from flask import url_for
 
+from builder.models import User, Role
+
+
+@pytest.fixture()
+def admin_login(login, admin):
+    return login(username='Luke', password='12345678')
+
 
 @pytest.mark.parametrize('view, kwargs, template', [
     ('users.list_users', {},  'users/list-users.html'),
@@ -10,13 +17,123 @@ from flask import url_for
     ('users.list_roles', {}, 'users/list-roles.html'),
     ('users.add_role', {}, 'users/add-role.html')
 ])
-def test_all_user_templates_with_success(view, kwargs, template, su_login, webtest, user):
+def test_templates(view, kwargs, template, su_login, webtest, user):
     response = webtest.get(url_for(view, **kwargs)).maybe_follow()
     assert response.template == template
 
 
-def test_set_unknown_id_in_user_details(su_login, webtest):
-    response = webtest.get(url_for('users.user_details', user_id=9999))
-    assert response.flashes == [('info', 'Usuário não existe!')]
+@pytest.mark.parametrize('endpoint',[('users.user_details'),('users.toggle_user'),])
+def test_set_unknown_id_in_user_details(endpoint, su_login, webtest):
+    response = webtest.get(url_for(endpoint, user_id=9999))
+    assert response.flashes == [('danger', 'Usuário não encontrado!')]
     response = response.maybe_follow()
     assert response.template == 'users/list-users.html'
+
+
+def test_toggle_use_with_success(su_login, user, webtest):
+    response = webtest.get(url_for('users.toggle_user', user_id=user.id))
+    assert response.flashes == [('success', 'Usuário {} foi desativado.'.format(user.username))]
+    user = User.query.get(user.id)
+    assert user.active is False
+
+
+def test_toggle_self_user_without_success(su_login, superuser, webtest):
+    response = webtest.get(url_for('users.toggle_user', user_id=superuser.id))
+    assert response.flashes == [('warning', 'Voce não pode alterar seus próprios usuário!')]
+
+
+def test_add_role_with_success(su_login, webtest):
+    response = webtest.get(url_for('users.add_role'))
+    form = response.form
+    form['name'] = 'test_role'
+    form['description'] = 'Permissão de teste'
+    form.submit().maybe_follow()
+    role = Role.search_role(name='test_role', exactly=True)
+    assert role.description == 'Permissão de teste'
+
+
+@pytest.mark.parametrize('role_name, flashed_message', [
+    ('superuser', [('danger', 'Permissão já existe!')]),
+    ('', [('danger', 'Nome da permissão inválida!')])
+])
+def test_add_role_without_success(role_name, flashed_message, su_login, webtest):
+    response = webtest.get(url_for('users.add_role'))
+    form = response.form
+    form['name'] = role_name
+    response = form.submit()
+    assert response.flashes == flashed_message
+
+
+def test_toggle_role_with_success(su_login, admin_role, webtest):
+    response = webtest.get(url_for('users.toggle_role', role_id=admin_role.id))
+    assert response.flashes == [('success', 'Permissão {} foi desativado.'.format(admin_role.name))]
+    role = Role.query.get(admin_role.id)
+    assert role.active is False
+
+
+def test_toggle_role_without_success(su_login, webtest):
+    response = webtest.get(url_for('users.toggle_role', role_id=999))
+    assert response.flashes == [('danger', 'Permissão não encontrada!')]
+    response = response.maybe_follow()
+    assert response.template == 'users/list-roles.html'
+
+
+def test_set_role_to_user(su_login, user, admin_role, webtest):
+    webtest.get(url_for('users.set_role', user_id=user.id, role_id=admin_role.id))
+    user = User.query.get(user.id)
+    assert user.roles[0].name == 'admin'
+
+
+def test_set_superuser_without_success(admin_login, user, superuser_role, webtest):
+    response = webtest.get(url_for('users.set_role', user_id=user.id, role_id=superuser_role.id))
+    assert response.flashes == [('danger', 'Permissão de superusuário só pode ser atribuída por outro superusuário')]
+    assert superuser_role not in user.roles
+
+
+def test_unset_role_to_user(su_login, admin, admin_role, webtest):
+    webtest.get(url_for('users.unset_role', user_id=admin.id, role_id=admin_role.id))
+    user = User.query.get(admin.id)
+    user.refresh()
+    assert user.roles == []
+
+
+def test_unset_superuser_without_success(admin_login, superuser, superuser_role, webtest):
+    response = webtest.get(url_for('users.unset_role', user_id=superuser.id, role_id=superuser_role.id))
+    assert response.flashes == [('danger', 'Permissão de superusuário só pode ser removida por outro superusuário')]
+    assert superuser_role in superuser.roles
+
+
+def test_remove_self_access_should_be_failed(su_login, superuser, superuser_role, webtest):
+    response = webtest.get(url_for('users.unset_role', user_id=superuser.id, role_id=superuser_role.id))
+    assert response.flashes == [('info', 'Não pode remover seus próprios acessos!')]
+    assert superuser_role in superuser.roles
+
+
+def test_set_already_added_permission(su_login, superuser, superuser_role, webtest):
+    response = webtest.get(url_for('users.set_role', user_id=superuser.id, role_id=superuser_role.id))
+    assert response.flashes == [('info', 'Usuário já tem essa permissão!')]
+
+
+def test_untset_already_removed_permission(su_login, admin, superuser_role, webtest):
+    response = webtest.get(url_for('users.unset_role', user_id=admin.id, role_id=superuser_role.id))
+    assert response.flashes == [('info', 'Usuário já não tem essa permissão!')]
+
+
+def test_set_permission_to_inexistent_user(su_login, admin_role, webtest):
+    response = webtest.get(url_for('users.set_role', user_id=999, role_id=admin_role.id))
+    assert response.flashes == [('danger', 'Erro ao adicionar permissão!')]
+
+
+def test_unset_permission_to_inexistent_user(su_login, admin_role, webtest):
+    response = webtest.get(url_for('users.unset_role', user_id=999, role_id=admin_role.id))
+    assert response.flashes == [('danger', 'Erro ao remover permissão!')]
+
+
+def test_set_inexistent_permission(su_login, admin, webtest):
+    response = webtest.get(url_for('users.set_role', user_id=admin.id, role_id=999))
+    assert response.flashes == [('danger', 'Erro ao adicionar permissão!')]
+
+
+def test_unset_inexistent_permission(su_login, admin, webtest):
+    response = webtest.get(url_for('users.unset_role', user_id=admin.id, role_id=999))
+    assert response.flashes == [('danger', 'Erro ao remover permissão!')]

--- a/tests/views/test_users.py
+++ b/tests/views/test_users.py
@@ -1,0 +1,22 @@
+# coding: utf-8
+import pytest
+from flask import url_for
+
+
+@pytest.mark.parametrize('view, kwargs, template', [
+    ('users.list_users', {},  'users/list-users.html'),
+    ('users.add_user', {}, 'users/add-user.html'),
+    ('users.user_details', {'user_id': '1'}, 'users/details-user.html'),
+    ('users.list_roles', {}, 'users/list-roles.html'),
+    ('users.add_role', {}, 'users/add-role.html')
+])
+def test_all_user_templates_with_success(view, kwargs, template, su_login, webtest, user):
+    response = webtest.get(url_for(view, **kwargs)).maybe_follow()
+    assert response.template == template
+
+
+def test_set_unknown_id_in_user_details(su_login, webtest):
+    response = webtest.get(url_for('users.user_details', user_id=9999))
+    assert response.flashes == [('info', 'Usuário não existe!')]
+    response = response.maybe_follow()
+    assert response.template == 'users/list-users.html'


### PR DESCRIPTION
# Adicionar testes as todas as visualizações existentes

Esse PR tem como finalidade resolver o débito técnico de que todas as views sejam testadas e com todas as formas possíveis de entrada.
## Conteúdo
- Adicionado a lib `flask-webtest` para fazer os testes de web
- Adicionado toda a estrutura para login via webtest
- Adicionado testes para todas as views e templates
## Bônus
- Alterado de `Suporte` para `Esqueci Minha Senha` na página de login
- Removido retorno do `__init__.py`  das views, que estava de forma redundante
- Corrigido algumas regras de negócio das views e mensagens de retorno

---

@mosesjr @FernandoLuizNemeChibli 
